### PR TITLE
修复微光分解信息Tooltip导致的掉帧问题

### DIFF
--- a/Common/GlobalItems/ImproveItem.cs
+++ b/Common/GlobalItems/ImproveItem.cs
@@ -211,7 +211,7 @@ public class ImproveItem : GlobalItem, IItemOverrideHover, IItemMiddleClickable
             text.Append("[i");
             if (result.stack != 1)
                 text.Append($"/s{result.stack}");
-            text.Append($":{result.netID}");
+            text.Append($":{result.netID}]");
         }
 
         tooltips.Add(new TooltipLine(Mod, "ShimmerResult", text.ToString()) { OverrideColor = new Color(241, 175, 233) });

--- a/Common/GlobalItems/ImproveItem.cs
+++ b/Common/GlobalItems/ImproveItem.cs
@@ -4,6 +4,7 @@ using ImproveGame.Common.ModSystems;
 using ImproveGame.Content;
 using ImproveGame.Core;
 using ImproveGame.UIFramework.SUIElements;
+using System.Text;
 using Terraria.GameContent.UI.Chat;
 
 namespace ImproveGame.Common.GlobalItems;
@@ -189,19 +190,31 @@ public class ImproveItem : GlobalItem, IItemOverrideHover, IItemMiddleClickable
 
         if (ItemID.Sets.CoinLuckValue[item.type] > 0)
         {
-            tooltips.Add(new TooltipLine(Mod, "ShimmerResult", GetText("Tips.ShimmerIntoWithCoinLuck", ItemID.Sets.CoinLuckValue[item.type])) { OverrideColor = new Color(241, 175, 233) });
+            tooltips.Add(
+                new TooltipLine(Mod, "ShimmerResult",
+                        GetText("Tips.ShimmerIntoWithCoinLuck", ItemID.Sets.CoinLuckValue[item.type]))
+                    { OverrideColor = new Color(241, 175, 233) });
             return;
         }
 
-        var items = RecipeSystem.ShimmerInto[item.type];
-        int stackRequired = RecipeSystem.ShimmerIntoWithStack[item.type];
+        // 微光
+        var items = CollectHelper.GetShimmerResult(item, out int stackRequired);
         if (items is null) return;
 
-        string text = stackRequired is not 1
+        var text = new StringBuilder();
+        text.Append(stackRequired is not 1
             ? GetText("Tips.ShimmerIntoWithStack", stackRequired)
-            : GetText("Tips.ShimmerInto");
-        items.ForEach(i => text += ItemTagHandler.GenerateTag(i));
-        tooltips.Add(new TooltipLine(Mod, "ShimmerResult", text) { OverrideColor = new Color(241, 175, 233) });
+            : GetText("Tips.ShimmerInto"));
+
+        foreach (var result in items)
+        {
+            text.Append("[i");
+            if (result.stack != 1)
+                text.Append($"/s{result.stack}");
+            text.Append($":{result.netID}");
+        }
+
+        tooltips.Add(new TooltipLine(Mod, "ShimmerResult", text.ToString()) { OverrideColor = new Color(241, 175, 233) });
     }
 
     private void TooltipMoreData(Item item, List<TooltipLine> tooltips)
@@ -211,7 +224,7 @@ public class ImproveItem : GlobalItem, IItemOverrideHover, IItemMiddleClickable
             return;
 
         tooltips.Add(new(Mod, "Quantity", "Quantity: " +
-            CurrentFrameProperties.ExistItems.GetTotalStack(item.type)));
+                                          CurrentFrameProperties.ExistItems.GetTotalStack(item.type)));
 
         tooltips.Add(new(Mod, "Value", $"Value: {item.value}"));
         tooltips.Add(new(Mod, "Rare", $"Rare: {item.rare}"));
@@ -221,7 +234,7 @@ public class ImproveItem : GlobalItem, IItemOverrideHover, IItemMiddleClickable
 
         if (item.shoot > ProjectileID.None)
         {
-            tooltips.Add(new(Mod, "Shoot", "Shoot: " + item.shoot)); 
+            tooltips.Add(new(Mod, "Shoot", "Shoot: " + item.shoot));
             tooltips.Add(new(Mod, "ShootSpeed", "ShootSpeed: " + item.shootSpeed));
         }
 

--- a/Common/ModSystems/RecipeSystem.cs
+++ b/Common/ModSystems/RecipeSystem.cs
@@ -17,22 +17,6 @@ public class RecipeSystem : ModSystem
     internal static RecipeGroup AnyAdamantiteBar;
     internal static RecipeGroup AnyGem;
 
-    public static Dictionary<int, int> ShimmerIntoWithStack;
-    public static Dictionary<int, List<Item>> ShimmerInto;
-
-    public override void PreUpdateItems()
-    {
-        if (ShimmerInto == null)
-        {
-            ShimmerInto = [];
-            ShimmerIntoWithStack = [];
-            for (int i = 1; i < ItemLoader.ItemCount; i++)
-            {
-                ShimmerInto.Add(i, CollectHelper.GetShimmerResult(new Item(i), out int stackRequired));
-                ShimmerIntoWithStack.Add(i, stackRequired);
-            }
-        }
-    }
     public override void Unload()
     {
         AnyCopperBar = null;
@@ -43,9 +27,6 @@ public class RecipeSystem : ModSystem
         AnyCobaltBar = null;
         AnyMythrilBar = null;
         AnyAdamantiteBar = null;
-
-        ShimmerIntoWithStack = null;
-        ShimmerInto = null;
     }
 
     public override void AddRecipeGroups()

--- a/Common/Utils/CollectHelper.cs
+++ b/Common/Utils/CollectHelper.cs
@@ -19,13 +19,13 @@ namespace ImproveGame.Common.Utils
             switch (shimmerEquivalentType)
             {
                 case 1326 when NPC.downedMoonlord:
-                    return new List<Item> {new(5335)};
+                    return [new Item(5335)];
                 case 779 when NPC.downedMoonlord:
-                    return new List<Item> {new(5134)};
+                    return [new Item(5134)];
                 case 3031 when NPC.downedMoonlord:
-                    return new List<Item> {new(5364)};
+                    return [new Item(5364)];
                 case 5364 when NPC.downedMoonlord:
-                    return new List<Item> {new(3031)};
+                    return [new Item(3031)];
                 case 3461:
                     {
                         short type = Main.GetMoonPhase() switch
@@ -40,18 +40,18 @@ namespace ImproveGame.Common.Utils
                             _ => 5406
                         };
 
-                        return new List<Item> {new(type)};
+                        return [new Item(type)];
                     }
                 default:
                     {
                         if (input.createTile is TileID.MusicBoxes)
                         {
-                            return new List<Item> {new(576)};
+                            return [new Item(576)];
                         }
 
                         if (ItemID.Sets.ShimmerTransformToItem[shimmerEquivalentType] > 0)
                         {
-                            return new List<Item> {new(ItemID.Sets.ShimmerTransformToItem[shimmerEquivalentType])};
+                            return [new Item(ItemID.Sets.ShimmerTransformToItem[shimmerEquivalentType])];
                         }
 
                         if (decraftingRecipeIndex >= 0)


### PR DESCRIPTION
经查是ItemTagHandler.GenerateTag方法的原因
现已修复
Close #89 